### PR TITLE
Replace obsolete `lexical-let` with `let`

### DIFF
--- a/too-long-lines-mode.el
+++ b/too-long-lines-mode.el
@@ -103,7 +103,7 @@ See also `too-long-lines-threshold', `too-long-lines-show-number-of-characters',
                       (setq already-hidden ov))))
               (if already-hidden
                   (move-overlay already-hidden (+ line-beg too-long-lines-show-number-of-characters) line-end)
-                (lexical-let (
+                (let (
                       (ov (make-overlay (+ line-beg too-long-lines-show-number-of-characters) line-end (current-buffer)))
                       (too-long-keymap (make-sparse-keymap))
                       (line-length line-length)


### PR DESCRIPTION
`lexical-let` is [obsolete](https://www.gnu.org/software/emacs/manual/html_node/cl/Obsolete-Lexical-Binding.html) since the introduction of true lexical binding in Emacs 24.1, and lexical-binding is enabled at the beginning of the file, so replace it with `let`.